### PR TITLE
Use fail_if_returned_late instead of hacking on the returned value

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -15,7 +15,7 @@ WriteMakefile(
 		'strict'                 => '0',
 		'warnings'               => '0',
 		'Attribute::Handlers'    => '0',
-		'Test::Class'            => '0.37',
+		'Test::Class'            => '0.51',
 	},
 	TEST_REQUIRES => {
 		'Test::More'             => '0',

--- a/README
+++ b/README
@@ -25,7 +25,7 @@ parent
 strict
 warnings
 Attribute::Handlers
-Test::Class 0.37
+Test::Class 0.51
 
 COPYRIGHT AND LICENCE
 

--- a/lib/Test/Class/WithStrictPlan.pm
+++ b/lib/Test/Class/WithStrictPlan.pm
@@ -9,20 +9,9 @@ use warnings;
 our $VERSION = '0.1';
 
 use parent 'Test::Class';
-BEGIN { Test::Class->VERSION('0.37') }
+BEGIN { Test::Class->VERSION('0.51') }
 sub fail_if_returned_early { 1 }
-
-use Attribute::Handlers;
-
-sub Test : ATTR(CODE, RAWDATA) {
-	my ($class, $symbol, $code_ref, $attr, $args) = @_;
-	no warnings 'redefine';
-	*{$symbol} = sub {
-		$code_ref->(@_);
-		return;
-	};
-	Test::Class::Test($class, $symbol, $code_ref, $attr, $args);
-}
+sub fail_if_returned_late { 1 }
 
 1;
 __END__

--- a/t/Test-Class-WithStrictPlan.t
+++ b/t/Test-Class-WithStrictPlan.t
@@ -1,15 +1,15 @@
 use strict;
 use warnings;
 
-use Test::More tests => 7;
+use Test::More tests => 9;
 
 BEGIN {
 	use_ok('Test::Class::WithStrictPlan');
 };
 
 my $less_out = qx("$^X" -Iblib/lib t/less.plx 2>&1);
-is($?, 255 << 8, 'Exit code for less number of tests is correct');
-like($less_out, qr/1\.\.1\nok 1 - First test passed\nok 2 - Second test passed\n.*expected 1 test.*2 completed.*planned 1 test but ran 2/s, 'Output for less number of tests is correct');
+is($?, 1 << 8, 'Exit code for less number of tests is correct');
+like($less_out, qr/1\.\.1\nok 1 - First test passed\nok 2 - Second test passed\nnot ok 3 - expected 1 test.* 2 completed/, 'Output for less number of tests is correct');
 
 my $more_out = qx("$^X" -Iblib/lib t/more.plx 2>&1);
 is($?, 1 << 8, 'Exit code for more number of tests is correct');
@@ -18,3 +18,7 @@ like($more_out, qr/1\.\.3\nok 1 - First test passed\nok 2 - Second test passed\n
 my $exact_out = qx("$^X" -Iblib/lib t/exact.plx 2>&1);
 is($?, 0 << 8, 'Exit code for exact number of tests is correct');
 like($exact_out, qr/1\.\.2\nok 1 - First test passed\nok 2 - Second test passed\n/, 'Output for exact number of tests is correct');
+
+my $noplan_out = qx("$^X" -Iblib/lib t/noplan.plx 2>&1);
+is($?, 1 << 8, 'Exit code for noplan is correct');
+like($noplan_out, qr/ok 1 - First test passed\nok 2 - Second test passed\nnot ok 3 - expected 1 test.* 2 completed.*ok 4 - First test passed/s, 'Output for noplan is correct');

--- a/t/noplan.plx
+++ b/t/noplan.plx
@@ -1,0 +1,19 @@
+#!/usr/bin/perl
+use warnings;
+use strict;
+
+{   package MyTest;
+    use parent 'Test::Class::WithStrictPlan';
+    use Test::More;
+
+    sub t01 : Test( 1 ) {
+        pass('First test passed');
+        pass('Second test passed');
+    }
+
+    sub t02 : Test( no_plan ) {
+        pass('First test passed');
+    }
+}
+
+MyTest->runtests;


### PR DESCRIPTION
Test::Class now supports both strict checks. They work even when
"no_plan" is specified somewhere, which didn't work previously. Test
added.